### PR TITLE
arm:dts:mtjade: temporary downgrade Host SPI-NOR frequency

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-ampere-mtjade.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-ampere-mtjade.dts
@@ -298,7 +298,7 @@
 		status = "okay";
 		m25p,fast-read;
 		label = "pnor";
-		/* spi-max-frequency = <100000000>; */
+		spi-max-frequency = <35000000>;
 	};
 };
 


### PR DESCRIPTION
Currently, After the HOST ON, openbmc can't detect the PNOR.
Once the driver probes again, it will inherit the previous setting (optimize reading),
without resetting the SPI Flash controller to default. It makes the kernel
can't read ID from flash chip device.

This patch will decrease SPI flash max frequency. It helps the kernel
always read ID success.

This issue just happen on MX25L25635E flash device. We will change back
50MHz after the issue is completely resolved.

Test case:
          - Turn ON the host
          - Switch Mux selection to BMC (set 0 to GPIO 226)
          - Unbind and bind again the SPI flash driver by command:
              # echo 1e630000.spi > /sys/bus/platform/drivers/aspeed-smc/unbind
              # echo 1e630000.spi > /sys/bus/platform/drivers/aspeed-smc/bind

Signed-off-by: Chanh Nguyen <chnguyen@amperecomputing.com>