### PR TITLE
arm:dts:mtjade: Enable I2C4 device access

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-ampere-mtjade.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-ampere-mtjade.dts
@@ -580,4 +580,11 @@
 			"","","","",
 	/*AC0-AC7*/	"SYS_PWR_GD","","","","","BMC_READY","SLAVE_PRESENT_L", \
 			"BMC_OCP_PG";
+
+	pin_gpio_y2 {
+		gpio-hog;
+		gpios = <ASPEED_GPIO(Y, 2) GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "BMC_GPIOY2_I2C4_O_EN";
+	};
 };


### PR DESCRIPTION
Set BMC_GPIOY2_I2C4_O_EN high to enable access to devices on the I2C4
bus.

Signed-off-by: Thang Q. Nguyen <thang@os.amperecomputing.com>