### PR TITLE
ARM: dts: aspeed: mtjade: enable MAC0 interface for NC-SI

### DIFF
--- a/arch/arm/boot/dts/aspeed-bmc-ampere-mtjade.dts
+++ b/arch/arm/boot/dts/aspeed-bmc-ampere-mtjade.dts
@@ -338,7 +338,13 @@
 };
 
 &mac0 {
-	status = "disabled";
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rmii1_default>;
+	clocks = <&syscon ASPEED_CLK_GATE_MAC1CLK>,
+		 <&syscon ASPEED_CLK_MAC1RCLK>;
+	clock-names = "MACCLK", "RCLK";
+	use-ncsi;
 };
 
 &mac1 {
@@ -565,7 +571,8 @@
 	/*O0-O7*/	"","","","","","","","",
 	/*P0-P7*/	"","","","","","","","",
 	/*Q0-Q7*/	"","","","","","UID_BUTTON","","",
-	/*R0-R7*/	"","","BMC_EXT_HIGHTEMP_L","","","RESET_BUTTON","","",
+	/*R0-R7*/	"","","BMC_EXT_HIGHTEMP_L","OCP_AUX_PWREN","OCP_MAIN_PWREN",
+			"RESET_BUTTON","","",
 	/*S0-S7*/	"","","","","","","","",
 	/*T0-T7*/	"","","","","","","","",
 	/*U0-U7*/	"","","","","","","","",

--- a/net/ncsi/ncsi-manage.c
+++ b/net/ncsi/ncsi-manage.c
@@ -131,8 +131,6 @@ static void ncsi_channel_monitor(struct timer_list *t)
 	case NCSI_CHANNEL_MONITOR_WAIT ... NCSI_CHANNEL_MONITOR_WAIT_MAX:
 		break;
 	default:
-		netdev_err(ndp->ndev.dev, "NCSI Channel %d timed out!\n",
-			   nc->id);
 		ncsi_report_link(ndp, true);
 		ndp->flags |= NCSI_DEV_RESHUFFLE;
 
@@ -1239,9 +1237,6 @@ static int ncsi_choose_active_channel(struct ncsi_dev_priv *ndp)
 	}
 
 	if (list_empty(&ndp->channel_queue) && found) {
-		netdev_info(ndp->ndev.dev,
-			    "NCSI: No channel with link found, configuring channel %u\n",
-			    found->id);
 		spin_lock_irqsave(&ndp->lock, flags);
 		list_add_tail_rcu(&found->link, &ndp->channel_queue);
 		spin_unlock_irqrestore(&ndp->lock, flags);

--- a/net/ncsi/ncsi-rsp.c
+++ b/net/ncsi/ncsi-rsp.c
@@ -1170,10 +1170,6 @@ int ncsi_rcv_rsp(struct sk_buff *skb, struct net_device *dev,
 		payload = ntohs(hdr->length);
 	ret = ncsi_validate_rsp_pkt(nr, payload);
 	if (ret) {
-		netdev_warn(ndp->ndev.dev,
-			    "NCSI: 'bad' packet ignored for type 0x%x\n",
-			    hdr->type);
-
 		if (nr->flags == NCSI_REQ_FLAG_NETLINK_DRIVEN) {
 			if (ret == -EPERM)
 				goto out_netlink;


### PR DESCRIPTION
Add definition for NC-SI interface in MAC0.
Add GPIO pins to setting the power sources of OCP cards in Mt.Jade platforms.

Testing:
	1. Flash new kernel to Mtjade system.
	2. Both eth0 and eth1 network interfaces should be up.

Signed-off-by: Thu B Nguyen <tbnguyen@amperecomputing.com>